### PR TITLE
replace ccmenuitemtoggler with custom toggler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(${PROJECT_NAME} SHARED
     src/manager/BrushManager.cpp
     src/ui/AlliumButtonBar.cpp
     src/ui/SupportPopup.cpp
+    src/ui/MenuItemTogglerExtra.cpp
     src/util/BrushDrawer.cpp
     src/util/CurveBrushDrawer.cpp
     src/util/DrawNodeExtension.cpp

--- a/include/Allium/ui/AlliumButtonBar.hpp
+++ b/include/Allium/ui/AlliumButtonBar.hpp
@@ -2,6 +2,8 @@
 
 #include <Geode/Geode.hpp>
 
+#include "MenuItemTogglerExtra.hpp"
+
 namespace allium {
     class BrushDrawer;
     class AlliumButtonBar : public cocos2d::CCNode {
@@ -9,11 +11,11 @@ namespace allium {
         geode::Ref<EditButtonBar> m_buttonBar;
         cocos2d::CCArray* m_buttons = nullptr;
 
-        CCMenuItemToggler* m_lineToggle = nullptr;
-        CCMenuItemToggler* m_curveToggle = nullptr;
-        CCMenuItemToggler* m_freeToggle = nullptr;
-        CCMenuItemToggler* m_polygonToggle = nullptr;
-        CCMenuItemToggler* m_textToggle = nullptr;
+        MenuItemTogglerExtra* m_lineToggle = nullptr;
+        MenuItemTogglerExtra* m_curveToggle = nullptr;
+        MenuItemTogglerExtra* m_freeToggle = nullptr;
+        MenuItemTogglerExtra* m_polygonToggle = nullptr;
+        MenuItemTogglerExtra* m_textToggle = nullptr;
         BrushDrawer* m_brushDrawer = nullptr;
 
     public:
@@ -36,14 +38,14 @@ namespace allium {
             std::function<void(CCMenuItemSpriteExtra*)> const& callback
         );
 
-        CCMenuItemToggler* addToggle(
+        MenuItemTogglerExtra* addToggle(
             std::string_view spriteName, std::string_view bgOnName, std::string_view bgOffName, std::string_view id, 
-            std::function<void(CCMenuItemToggler*)> const& callback
+            std::function<void(MenuItemTogglerExtra*)> const& callback
         );
 
-        CCMenuItemToggler* addDefaultToggle(
-            std::string_view spriteName, std::string_view id, 
-            std::function<void(CCMenuItemToggler*)> const& callback
+        MenuItemTogglerExtra* addDefaultToggle(
+            std::string_view spriteName, std::string_view id,
+            std::function<void(MenuItemTogglerExtra*)> const& callback
         );
     };
 }

--- a/include/Allium/ui/MenuItemTogglerExtra.hpp
+++ b/include/Allium/ui/MenuItemTogglerExtra.hpp
@@ -5,6 +5,7 @@
 namespace allium {
     // the EditButtonBar expects all children to be CCMenuItemSpriteExtra and will create a crash otherwise
     // this is intended to be a quick replacement for CCMenuItemExt::createToggler
+    // thanks to https://github.com/hiimjasmine00/BetterEdit/blob/b505161a0bee587f6241201198b1587540ac9e06/src/features/ViewTab/ViewTab.cpp#L25 :)
     class MenuItemTogglerExtra : public CCMenuItemSpriteExtra {
     protected:
         std::function<void(MenuItemTogglerExtra*)> m_callback;

--- a/include/Allium/ui/MenuItemTogglerExtra.hpp
+++ b/include/Allium/ui/MenuItemTogglerExtra.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <Geode/Geode.hpp>
+
+namespace allium {
+    // the EditButtonBar expects all children to be CCMenuItemSpriteExtra and will create a crash otherwise
+    // this is intended to be a quick replacement for CCMenuItemExt::createToggler
+    class MenuItemTogglerExtra : public CCMenuItemSpriteExtra {
+    protected:
+        std::function<void(MenuItemTogglerExtra*)> m_callback;
+        geode::Ref<cocos2d::CCNode> m_onSprite;
+        geode::Ref<cocos2d::CCNode> m_offSprite;
+        bool m_toggled = false;
+
+        void onCallback(cocos2d::CCObject*);
+        void updateToggleSprite();
+
+        bool init(
+            cocos2d::CCNode* onSprite, cocos2d::CCNode* offSprite,
+            std::function<void(MenuItemTogglerExtra*)> callback
+        );
+
+    public:
+        static MenuItemTogglerExtra* create(
+            cocos2d::CCNode* onSprite, cocos2d::CCNode* offSprite,
+            std::function<void(MenuItemTogglerExtra*)> callback
+        );
+
+        void toggle(bool);
+        bool isToggled() const;
+    };
+}

--- a/src/ui/AlliumButtonBar.cpp
+++ b/src/ui/AlliumButtonBar.cpp
@@ -205,16 +205,16 @@ CCMenuItemSpriteExtra* AlliumButtonBar::addButton(
     return button;
 }
 
-CCMenuItemToggler* AlliumButtonBar::addDefaultToggle(
-    std::string_view spriteName, std::string_view id, 
-    std::function<void(CCMenuItemToggler*)> const& callback
+MenuItemTogglerExtra* AlliumButtonBar::addDefaultToggle(
+    std::string_view spriteName, std::string_view id,
+    std::function<void(MenuItemTogglerExtra*)> const& callback
 ) {
     return this->addToggle(spriteName, "DeactiveButton.png"_spr, "ActiveButton.png"_spr, id, callback);
 }
 
-CCMenuItemToggler* AlliumButtonBar::addToggle(
+MenuItemTogglerExtra* AlliumButtonBar::addToggle(
     std::string_view spriteName, std::string_view bgOnName, std::string_view bgOffName, std::string_view id, 
-    std::function<void(CCMenuItemToggler*)> const& callback
+    std::function<void(MenuItemTogglerExtra*)> const& callback
 ) {
     auto sprite = CCSprite::createWithSpriteFrameName(spriteName.data());
     auto bgOff = CCSprite::create(bgOffName.data());
@@ -224,12 +224,10 @@ CCMenuItemToggler* AlliumButtonBar::addToggle(
     auto bgOn = CCSprite::create(bgOnName.data());
     bgOn->addChildAtPosition(sprite, Anchor::Center, ccp(0, 0));
 
-    auto button = CCMenuItemExt::createToggler(
+    auto button = MenuItemTogglerExtra::create(
         bgOn,
         bgOff,
-        [=](CCObject* sender) {
-            callback(static_cast<CCMenuItemToggler*>(sender));
-        }
+        callback
     );
     button->setID(id.data());
     m_buttons->addObject(button);

--- a/src/ui/MenuItemTogglerExtra.cpp
+++ b/src/ui/MenuItemTogglerExtra.cpp
@@ -1,0 +1,57 @@
+#include <ui/MenuItemTogglerExtra.hpp>
+
+using namespace allium;
+using namespace geode::prelude;
+
+MenuItemTogglerExtra* MenuItemTogglerExtra::create(
+    cocos2d::CCNode* onSprite, cocos2d::CCNode* offSprite,
+    std::function<void(MenuItemTogglerExtra*)> callback
+) {
+    auto ret = new (std::nothrow) MenuItemTogglerExtra();
+    if (ret && ret->init(onSprite, offSprite, callback)) {
+        ret->autorelease();
+        return ret;
+    }
+    delete ret;
+    return nullptr;
+}
+
+void MenuItemTogglerExtra::onCallback(cocos2d::CCObject*) {
+    m_callback(this);
+    toggle(!m_toggled);
+}
+
+bool MenuItemTogglerExtra::init(
+    cocos2d::CCNode* onSprite, cocos2d::CCNode* offSprite,
+    std::function<void(MenuItemTogglerExtra*)> callback
+) {
+    if (!CCMenuItemSpriteExtra::init(
+        offSprite, nullptr, this,
+        static_cast<SEL_MenuHandler>(&MenuItemTogglerExtra::onCallback))
+    ) {
+        return false;
+    }
+
+    m_callback = callback;
+    m_onSprite = onSprite;
+    m_offSprite = offSprite;
+
+    return true;
+}
+
+void MenuItemTogglerExtra::updateToggleSprite() {
+    auto sprite = m_toggled ? m_onSprite : m_offSprite;
+
+    // why does setSprite take a sprite when it only needs a node
+    this->setNormalImage(*sprite);
+    this->updateSprite();
+}
+
+void MenuItemTogglerExtra::toggle(bool toggled) {
+    m_toggled = toggled;
+    this->updateToggleSprite();
+}
+
+bool MenuItemTogglerExtra::isToggled() const {
+    return m_toggled;
+}


### PR DESCRIPTION
half based on [this](https://github.com/hiimjasmine00/BetterEdit/blob/b505161a0bee587f6241201198b1587540ac9e06/src/features/ViewTab/ViewTab.cpp#L25) but more the idea of it. should fix the crashes on mac/ios (at least, from what i've tested)

i couldn't come up with a good name for it.  `CCMenuItemSpriteExtraTogglerExt`