### PR TITLE
fix gaps between straight line segments not being filled in

### DIFF
--- a/src/util/CurveBrushDrawer.cpp
+++ b/src/util/CurveBrushDrawer.cpp
@@ -74,6 +74,11 @@ std::unique_ptr<BaseConverter> CurveBrushDrawer::initializeConverter() {
     std::vector<Point> points;
     points.insert(points.end(), m_previousPoints.begin(), m_previousPoints.end());
     points.insert(points.end(), m_currentPoints.begin(), m_currentPoints.end());
+    // remove consecutive duplicate points
+    auto newEnd = std::unique(points.begin(), points.end(), [](const Point& a, const Point& b) {
+        return a == b;
+    });
+    points.erase(newEnd, points.end());
     return std::make_unique<PolylineConverter>(
         BrushManager::get()->getLineWidth(), std::move(points)
     );


### PR DESCRIPTION
this fixes a bug with the polyline tool where when drawing lines (clicking in place rather than dragging), the gaps between the lines aren't filled in.

before this fix:
<img width="976" height="492" alt="image" src="https://github.com/user-attachments/assets/d644a379-a033-4382-aa5a-7a425c2e3a5e" />

after this fix:
<img width="1039" height="511" alt="image" src="https://github.com/user-attachments/assets/a873e7c8-143b-4318-8a54-5f77d726b453" />

it seems when drawing straight lines, the points returned from `CurveBrushDrawer::getGeneratedPoints` are doubled up. as an example:

```
segment 1: [A, B, B]
segment 2: [B, C, C]
combined:  [A, B, B, C, C]
```

this causes an issue with the logic that handles filling in gaps and so it doesn't do anything. i fixed this by using `std::unique` to remove consecutive duplicate points. perhaps there are better ways of doing this, this just felt like the most "there's no way this could possibly fuck up" solution.